### PR TITLE
Implemented health checks for worker & API; updated depends_on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "async-trait",
+ "axum",
  "axum-server",
  "clap",
  "data-model-ltx",
@@ -4278,6 +4279,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 name = "worker-ltx"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "core-ltx",
  "data-model-ltx",

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-client \
     libc6 \
     ca-certificates \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 ###
@@ -226,6 +227,7 @@ FROM runtime-base AS worker
 WORKDIR /app
 # Worker binary
 COPY --from=worker-build /app/bin/worker-ltx /usr/local/bin/worker-ltx
+EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/worker-ltx"]
 
 ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,12 @@ services:
     ports:
       - "443:3000"
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "--no-check-certificate", "https://localhost:3000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
     volumes:
       - ./certs:/app/certs:ro
     depends_on:
@@ -94,10 +100,19 @@ services:
       RUST_LOG: info
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       WORKER_MAX_CONCURRENCY: ${WORKER_MAX_CONCURRENCY:-1000}
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
     depends_on:
       postgres:
         condition: service_healthy
-      # TODO: depends_on api for condition service_healthy too! but API server needs healthcheck
+      api:
+        condition: service_healthy
     networks:
       - ltx_network
     develop:
@@ -136,8 +151,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      # TODO: depends_on api for condition service_healthy too! but API server needs healthcheck
-      # TODO: depends_on worker for condition service_healthy too! but worker needs healthcheck
+      api:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
     networks:
       - ltx_network
     develop:

--- a/src/api-ltx/src/routes/mod.rs
+++ b/src/api-ltx/src/routes/mod.rs
@@ -2,7 +2,7 @@ use axum::{
     Router, middleware,
     routing::{get, post, put},
 };
-use core_ltx::AuthConfig;
+use core_ltx::{AuthConfig, health_check};
 use std::sync::Arc;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
@@ -45,6 +45,7 @@ pub fn router(auth_config: Option<AuthConfig>) -> Router<DbPool> {
 
     // Combine all routes
     Router::new()
+        .route("/health", get(health_check))
         .merge(auth_routes)
         .merge(protected_routes)
         // Serve static assets from frontend pkg directory (no auth required)

--- a/src/core-ltx/Cargo.toml
+++ b/src/core-ltx/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 async-openai = { workspace = true }
+axum = { workspace = true }
 axum-server = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }

--- a/src/core-ltx/src/common/health.rs
+++ b/src/core-ltx/src/common/health.rs
@@ -1,0 +1,9 @@
+use axum::{Router, http::StatusCode};
+
+pub async fn health_check() -> (StatusCode, &'static str) {
+    (StatusCode::OK, "healthy")
+}
+
+pub fn health_router() -> Router {
+    Router::new().route("/health", axum::routing::get(health_check))
+}

--- a/src/core-ltx/src/common/mod.rs
+++ b/src/core-ltx/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_config;
 pub mod db_env;
+pub mod health;
 pub mod hostname;
 pub mod logging;
 pub mod max_concurrency;

--- a/src/core-ltx/src/lib.rs
+++ b/src/core-ltx/src/lib.rs
@@ -9,6 +9,7 @@ pub use web_html::{download, is_valid_url, parse_html};
 
 pub use common::auth_config::{AuthConfig, get_auth_config, is_auth_enabled};
 pub use common::db_env::get_db_pool;
+pub use common::health::{health_check, health_router};
 pub use common::hostname::{HostPortError, get_api_base_url};
 pub use common::logging::setup_logging;
 pub use common::max_concurrency::get_max_concurrency;

--- a/src/worker-ltx/Cargo.toml
+++ b/src/worker-ltx/Cargo.toml
@@ -7,8 +7,9 @@ license = { workspace = true }
 description = "Backend worker executing logic (generation + update) from API sever into database."
 
 [dependencies]
-tokio = { workspace = true }
+axum = { workspace = true }
 diesel = { workspace = true }
+tokio = { workspace = true }
 diesel-async = { workspace = true }
 deadpool = { workspace = true }
 dotenvy = { workspace = true }


### PR DESCRIPTION
Adds a shared axum router for performing a healthcheck in `core_ltx`.
It returns a static string as an HTTP 200 OK.

The worker spawns a small server to provide this healthcheck on port 8080.
The API server integrates this route.

The docker-compose.yml file now includes the healthcheck in the `api` and `worker` services.

The `worker` service now `depends_on` the `api` service being healthy.
The `cron` updater service now `depends_on ` the `api` and `worker` services being healthy.