### PR TITLE
Fail-fast check for required auth-related env vars when ENABLE_AUTH=1

### DIFF
--- a/src/api-ltx/src/main.rs
+++ b/src/api-ltx/src/main.rs
@@ -1,6 +1,7 @@
+use std::env;
 use std::net::SocketAddr;
 
-use core_ltx::{get_api_base_url, get_auth_config, get_db_pool, get_tls_config, setup_logging};
+use core_ltx::{get_api_base_url, get_auth_config, get_db_pool, get_tls_config, is_auth_enabled, setup_logging};
 use tracing::info;
 
 use api_ltx::routes;
@@ -12,6 +13,38 @@ async fn main() {
 
     // Load environment variables from .env file
     dotenvy::dotenv().ok();
+
+    // Fail-fast check: verify required auth env vars are present if auth is enabled
+    if is_auth_enabled() {
+        let required_vars = ["AUTH_PASSWORD_HASH", "SESSION_SECRET"];
+        for var_name in &required_vars {
+            match env::var(var_name) {
+                Ok(value) if !value.trim().is_empty() => {
+                    // Variable is present and non-empty, continue
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "FATAL: {} environment variable is set but empty. \
+                         Authentication is enabled (ENABLE_AUTH=true) but required configuration is invalid.",
+                        var_name
+                    );
+                    std::process::exit(1);
+                }
+                Err(_) => {
+                    eprintln!(
+                        "FATAL: {} environment variable is required when ENABLE_AUTH=true.",
+                        var_name
+                    );
+                    if var_name == &"AUTH_PASSWORD_HASH" {
+                        eprintln!("Generate a hash with: cargo run --bin generate-password-hash -- your_password");
+                    } else if var_name == &"SESSION_SECRET" {
+                        eprintln!("Generate a secret with: openssl rand -base64 32");
+                    }
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
 
     setup_logging("api_ltx=debug,tower_http=debug");
 

--- a/src/cron-ltx/src/main.rs
+++ b/src/cron-ltx/src/main.rs
@@ -2,7 +2,9 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
-use core_ltx::{TimeUnit, get_api_base_url, get_auth_config, get_db_pool, get_poll_interval, setup_logging};
+use core_ltx::{
+    TimeUnit, get_api_base_url, get_auth_config, get_db_pool, get_poll_interval, is_auth_enabled, setup_logging,
+};
 use cron_ltx::AuthenticatedClient;
 use data_model_ltx::db::DbPool;
 
@@ -13,6 +15,38 @@ async fn main() {
 
     // Load environment variables from .env file., if it exists
     dotenvy::dotenv().ok();
+
+    // Fail-fast check: verify required auth env vars are present if auth is enabled
+    if is_auth_enabled() {
+        let required_vars = ["AUTH_PASSWORD_HASH", "SESSION_SECRET"];
+        for var_name in &required_vars {
+            match env::var(var_name) {
+                Ok(value) if !value.trim().is_empty() => {
+                    // Variable is present and non-empty, continue
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "FATAL: {} environment variable is set but empty. \
+                         Authentication is enabled (ENABLE_AUTH=true) but required configuration is invalid.",
+                        var_name
+                    );
+                    std::process::exit(1);
+                }
+                Err(_) => {
+                    eprintln!(
+                        "FATAL: {} environment variable is required when ENABLE_AUTH=true.",
+                        var_name
+                    );
+                    if var_name == &"AUTH_PASSWORD_HASH" {
+                        eprintln!("Generate a hash with: cargo run --bin generate-password-hash -- your_password");
+                    } else if var_name == &"SESSION_SECRET" {
+                        eprintln!("Generate a secret with: openssl rand -base64 32");
+                    }
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
 
     setup_logging("cron_ltx=debug");
 


### PR DESCRIPTION
The API server & cron updater service now check for their respective required auth-related environment variables. If there are any problems, they display a helpful error message and fail immediately.