### PR TITLE
Refactor auth env var check + cron needs TLS_KEY_PATH and TLS_CERT_PATH

### DIFF
--- a/src/core-ltx/src/common/env_check.rs
+++ b/src/core-ltx/src/common/env_check.rs
@@ -1,0 +1,36 @@
+/// Ensures that the listed environment variables exist and are non-empty.
+/// Panics on error.
+pub fn check_non_empty_env_vars(required_vars: &[&str]) {
+    let mut any_error: u32 = 0;
+    for var_name in required_vars {
+        let var_name = *var_name;
+        match std::env::var(var_name) {
+            Ok(value) if !value.trim().is_empty() => {
+                // Variable is present and non-empty, continue
+            }
+            Ok(_) => {
+                eprintln!(
+                    "FATAL: {} environment variable is set but empty. \
+                   Authentication is enabled (ENABLE_AUTH=true) but required configuration is invalid.",
+                    var_name
+                );
+                any_error += 1;
+            }
+            Err(_) => {
+                if var_name == "AUTH_PASSWORD_HASH" {
+                    eprintln!("Generate a hash with: cargo run --bin generate-password-hash -- your_password");
+                } else if var_name == "SESSION_SECRET" {
+                    eprintln!("Generate a secret with: openssl rand -base64 32");
+                }
+                eprintln!(
+                    "FATAL: {} environment variable is required when ENABLE_AUTH=true.",
+                    var_name
+                );
+                any_error += 1;
+            }
+        }
+    }
+    if any_error > 0 {
+        panic!("{} environment variables failed checks.", any_error);
+    }
+}

--- a/src/core-ltx/src/common/mod.rs
+++ b/src/core-ltx/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_config;
 pub mod db_env;
+pub mod env_check;
 pub mod health;
 pub mod hostname;
 pub mod logging;

--- a/src/cron-ltx/src/main.rs
+++ b/src/cron-ltx/src/main.rs
@@ -1,7 +1,8 @@
-use std::env;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{env, path::PathBuf};
 
+use core_ltx::common::env_check::check_non_empty_env_vars;
 use core_ltx::{
     TimeUnit, get_api_base_url, get_auth_config, get_db_pool, get_poll_interval, is_auth_enabled, setup_logging,
 };
@@ -18,32 +19,19 @@ async fn main() {
 
     // Fail-fast check: verify required auth env vars are present if auth is enabled
     if is_auth_enabled() {
-        let required_vars = ["AUTH_PASSWORD_HASH", "SESSION_SECRET"];
-        for var_name in &required_vars {
-            match env::var(var_name) {
-                Ok(value) if !value.trim().is_empty() => {
-                    // Variable is present and non-empty, continue
-                }
-                Ok(_) => {
-                    eprintln!(
-                        "FATAL: {} environment variable is set but empty. \
-                         Authentication is enabled (ENABLE_AUTH=true) but required configuration is invalid.",
-                        var_name
-                    );
-                    std::process::exit(1);
-                }
-                Err(_) => {
-                    eprintln!(
-                        "FATAL: {} environment variable is required when ENABLE_AUTH=true.",
-                        var_name
-                    );
-                    if var_name == &"AUTH_PASSWORD_HASH" {
-                        eprintln!("Generate a hash with: cargo run --bin generate-password-hash -- your_password");
-                    } else if var_name == &"SESSION_SECRET" {
-                        eprintln!("Generate a secret with: openssl rand -base64 32");
-                    }
-                    std::process::exit(1);
-                }
+        check_non_empty_env_vars(&["AUTH_PASSWORD_HASH", "SESSION_SECRET", "TLS_KEY_PATH", "TLS_CERT_PATH"]);
+
+        // we know these are non-empty -- ok to unwrap
+        for var_name in &["TLS_KEY_PATH", "TLS_CERT_PATH"] {
+            let val = env::var(var_name).unwrap();
+            let path = PathBuf::from(val);
+            if !path.is_file() {
+                eprintln!(
+                    "FATAL: {} points to file {}, but the file does not exist!",
+                    var_name,
+                    path.display()
+                );
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
- refactors auth env var checking into reusable function `core_ltx::common::env_check::check_non_empty_env_vars`
- changes the behavior to `panic!` instead of process exit
- lists all problems before panic-ing
- `cron-ltx` also checks that `TLS_KEY_PATH` and `TLS_CERT_PATH` are non-empty and point to valid files